### PR TITLE
Made changes to appropriate java files to fix raster download methods…

### DIFF
--- a/geoportal_1/src/main/java/org/opengeoportal/download/methods/WcsDownloadMethod.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/download/methods/WcsDownloadMethod.java
@@ -2,6 +2,7 @@ package org.opengeoportal.download.methods;
 
 import java.io.InputStream;
 import java.util.HashSet;
+
 import java.util.List;
 import java.util.Set;
 
@@ -58,16 +59,19 @@ public class WcsDownloadMethod extends AbstractDownloadMethod implements PerLaye
 		SolrRecord layerInfo = this.currentLayer.getLayerInfo();
 		
 		Envelope env = describeLayerInfo.getLonLatEnvelope();
-		BoundingBox nativeBounds = new BoundingBox(env.getMinX(), env.getMinY(), env.getMaxX(), env.getMaxY());
+		BoundingBox nativeLatLon = new BoundingBox(env.getMinX(), env.getMinY(), env.getMaxX(), env.getMaxY());
 		logger.info("reqLatLon" + this.currentLayer.getRequestedBounds().toStringLatLon());
-		logger.info("natLatLon" + nativeBounds.toStringLatLon());
+		logger.info("natLatLon" + nativeLatLon.toStringLatLon());
 
-		BoundingBox bounds = nativeBounds.getIntersection(this.currentLayer.getRequestedBounds());
+		BoundingBox bounds = nativeLatLon.getIntersection(this.currentLayer.getRequestedBounds());
 		logger.info("intLatLon" + bounds.toStringLatLon());
 
+		//  BEN ADDED... 
+		Envelope nativeEnv = describeLayerInfo.getNativeEnvelope();
+		BoundingBox nativeBbox = new BoundingBox(nativeEnv.getMinX(), nativeEnv.getMinY(), nativeEnv.getMaxX(), nativeEnv.getMaxY());
+		//
+
 		String layerName = this.currentLayer.getLayerNameNS();
-
-
 		
 		/*
 		String epsgCode = describeLayerInfo.get("SRS");
@@ -129,8 +133,10 @@ public class WcsDownloadMethod extends AbstractDownloadMethod implements PerLaye
 		*/
 		int epsgCode = 4326;
 		String format = "geotiff";
-		return WcsGetCoverage1_0_0.createWcsGetCoverageRequest(layerName, describeLayerInfo, bounds, epsgCode, format);
-		//return getCoverageRequest;	 
+		// BEN ADDED nativeBboxValues
+		return WcsGetCoverage1_0_0.createWcsGetCoverageRequest(layerName, describeLayerInfo, bounds, epsgCode, format, nativeBbox);
+		//
+		//return getCoverageRequest;	
 	}
 	
 	@Override

--- a/geoportal_1/src/main/java/org/opengeoportal/download/methods/WmsDownloadMethod.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/download/methods/WmsDownloadMethod.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import com.fasterxml.jackson.core.JsonParseException;
 
 public class WmsDownloadMethod extends AbstractDownloadMethod implements PerLayerDownloadMethod {	
-	private static final Double MAX_AREA =  1800.0 * 1800.0;  //should be within recommended geoserver memory settings.
+	private static final Double MAX_AREA =  1800.0 * 1800.0;
 	private static final Boolean INCLUDES_METADATA = false;
 	final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/CoverageOffering1_0_0.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/CoverageOffering1_0_0.java
@@ -68,7 +68,9 @@ public class CoverageOffering1_0_0 implements OwsDescribeInfo{
 	String label;
 	
 	Envelope lonLatEnvelope;
-	
+	//Ben ADDED
+	Envelope nativeEnvelope;
+	//
 	List<String> keywords;
 	
 	RectifiedGrid rectifiedGrid;
@@ -105,6 +107,14 @@ public class CoverageOffering1_0_0 implements OwsDescribeInfo{
 	public void setLonLatEnvelope(Envelope lonLatEnvelope) {
 		this.lonLatEnvelope = lonLatEnvelope;
 	}
+	// BEN ADDED
+	public Envelope getNativeEnvelope() {
+		return nativeEnvelope;
+	}
+	public void setNativeEnvelope(Envelope nativeEnvelope) {
+		this.nativeEnvelope = nativeEnvelope;
+	}
+	//
 	public List<String> getKeywords() {
 		return keywords;
 	}

--- a/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/WcsDescribeCoverage1_0_0.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/WcsDescribeCoverage1_0_0.java
@@ -3,6 +3,7 @@ package org.opengeoportal.ogc.wcs.wcs1_0_0;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,7 +67,7 @@ public class WcsDescribeCoverage1_0_0 implements OgcInfoRequest {
 		return new Envelope(minX, minY, maxX, maxY, srsName);
 
 	}
-	
+		
 	public static List<String> parseKeywords(Node keywordsNode){
 
 		NodeList keywordNodes = keywordsNode.getChildNodes();
@@ -230,6 +231,10 @@ public class WcsDescribeCoverage1_0_0 implements OgcInfoRequest {
 			} else if (nodeName.equalsIgnoreCase("domainSet")){
 				Node sdNode = OgpXmlUtils.getChildNode(currentDetail, "spatialDomain");
 				Node rgNode = OgpXmlUtils.getChildNode(sdNode, "RectifiedGrid");
+				//BEN ADDED
+				Node nativeEnvelopeNode = OgpXmlUtils.getChildNode(sdNode,"Envelope");
+				coverageOffering.setNativeEnvelope(parseLonLatEnvelope(nativeEnvelopeNode));
+				//
 				coverageOffering.setRectifiedGrid(parseRectifiedGrid(rgNode));
 			} else if (nodeName.equalsIgnoreCase("rangeSet")){
 				// 

--- a/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/WcsGetCoverage1_0_0.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/WcsGetCoverage1_0_0.java
@@ -2,6 +2,9 @@ package org.opengeoportal.ogc.wcs.wcs1_0_0;
 
 import java.util.List;
 
+// BEN ADDED
+import java.util.HashMap;
+//
 import org.geotools.factory.Hints;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.ReferencingFactoryFinder;
@@ -30,8 +33,8 @@ public class WcsGetCoverage1_0_0 {
 		}
 		return false;
 	}
-	
-	public static String createWcsGetCoverageRequest(String layerName, CoverageOffering1_0_0 coverageOffering, BoundingBox bounds, int epsgCode, String outputFormat) throws Exception {
+
+	public static String createWcsGetCoverageRequest(String layerName, CoverageOffering1_0_0 coverageOffering, BoundingBox bounds, int epsgCode, String outputFormat, BoundingBox nativeBbox) throws Exception {
 		//http://data.fao.org/maps/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=lus_mna_31661&bbox=-13.166733,39.766613,12.099957,63.333236&crs=EPSG:4326&format=geotiff&width=917&height=331
 
 			List<String> supportedFormats = coverageOffering.getSupportedFormats();
@@ -46,23 +49,67 @@ public class WcsGetCoverage1_0_0 {
 			Hints hints = new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, Boolean.TRUE);
 			CRSAuthorityFactory factory = ReferencingFactoryFinder.getCRSAuthorityFactory("EPSG", hints);
 			CoordinateReferenceSystem sourceCRS = factory.createCoordinateReferenceSystem("EPSG:4326");
-			
+
+		    //The bounding box is created in EPSG 4326.  The line below takes the corrdinates given and references to the sourceCRS (EPSG:4326).
+		    //The envelope is then transformed to the native (targetCRS) bounds below.		    
 		    ReferencedEnvelope envelope = new ReferencedEnvelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY(), sourceCRS);
 		    logger.info("requested Bounds: " + OgpUtils.referencedEnvelopeToString(envelope));
+		    
 		    // Transform using 10 sample points around the envelope
-
 		    CoordinateReferenceSystem targetCRS = factory.createCoordinateReferenceSystem(coverageOffering.getSupportedCRSs().get(0));
 
 		    ReferencedEnvelope result = envelope.transform(targetCRS, true, 10);
 
-		 String getCoverageRequest = "service=WCS&version=" + VERSION + 
-		 		"&request=GetCoverage&coverage=" + layerName +
-				"&bbox=" + OgpUtils.referencedEnvelopeToString(result) +
-				"&crs=" + coverageOffering.getSupportedCRSs().get(0) + 
-				"&format=" + outputFormat;
-		 
-		getCoverageRequest += generateSize(coverageOffering.getRectifiedGrid());
+		ReferencedEnvelope nativeRefEnv = new ReferencedEnvelope(nativeBbox.getMinX(), nativeBbox.getMaxX(), nativeBbox.getMinY(), nativeBbox.getMaxY(), targetCRS);
 		
+		Double resX = coverageOffering.getRectifiedGrid().getResx();
+		Double resY = coverageOffering.getRectifiedGrid().getResy();
+
+		Double xMin, yMin, xMax, yMax;
+
+		if ( nativeRefEnv.getMinimum(0) > result.getMinimum(0)){
+			xMin = nativeRefEnv.getMinimum(0);
+		} else {
+			Double x_a = (Math.abs(result.getMinimum(0) - nativeRefEnv.getMinimum(0)))/resX;
+			xMin = nativeRefEnv.getMinimum(0) + (x_a.intValue() * resX);    }
+
+		if ( nativeRefEnv.getMinimum(1) > result.getMinimum(1)){
+			yMin = nativeRefEnv.getMinimum(1);
+		} else {
+			Double y_a = (Math.abs(result.getMinimum(1) - nativeRefEnv.getMinimum(1)))/resY;
+			yMin = nativeRefEnv.getMinimum(1) + (y_a.intValue() * resY);    }
+
+
+		if ( nativeRefEnv.getMaximum(0) < result.getMaximum(0)){
+			xMax = nativeRefEnv.getMaximum(0);
+		} else {
+			Double x_b = (Math.abs(result.getMaximum(0) - nativeRefEnv.getMaximum(0)))/resX;
+			xMax = nativeRefEnv.getMaximum(0) - (x_b.intValue() * resX);    }
+
+
+		if ( nativeRefEnv.getMaximum(1) < result.getMaximum(1)){
+			yMax = nativeRefEnv.getMaximum(1);
+		} else {
+			Double y_b = (Math.abs(result.getMaximum(1) - nativeRefEnv.getMaximum(1)))/resY;
+			yMax =  nativeRefEnv.getMaximum(1) - (y_b.intValue() * resY);   }
+
+		String bbox = "&bbox=" + Double.toString(xMin) + "," + Double.toString(yMin) + "," + Double.toString(xMax) + "," + Double.toString(yMax);
+		Double dwidth = (Math.abs(xMax - xMin))/resX;
+		Double dheight = (Math.abs(yMax - yMin))/resY;
+		int width = dwidth.intValue();
+		int height = dheight.intValue();
+		
+		String widthHeight = "&width=" + width + "&height=" + height;
+		
+		    String getCoverageRequest = "service=WCS&version=" + VERSION + 
+		 		"&request=GetCoverage&coverage=" + layerName +
+				bbox +				
+				//"&bbox=" + OgpUtils.referencedEnvelopeToString(result) +
+				// "&bbox=" + OgpUtils.referencedEnvelopeToString(result) +
+				"&crs=" + coverageOffering.getSupportedCRSs().get(0) + 
+				"&format=" + outputFormat +
+				widthHeight;
+				
     	return getCoverageRequest;
 	}
 	
@@ -94,5 +141,35 @@ public class WcsGetCoverage1_0_0 {
 
 		 return size;
 	}
+	/*
+	private static String generateSize(RectifiedGrid rgrid) throws Exception{
+		Integer width = rgrid.getWidth();
+		Integer height = rgrid.getHeight();		
+		
+		String size = "&";
+		
+		if (width.equals(null) || height.equals(null)){
+			Double resx = rgrid.getResx();
+			Double resy = rgrid.getResy();
+			if (!resx.isNaN() && !resy.isNaN()) {
+				size += "resx=";
+				size += Double.toString(resx);
+				size += "&resy=";
+				size += Double.toString(resy);
+			} else {
+				throw new Exception("invalid describe coverage response....could not form getCoverage request.");
+			}
+
+		} else {
+			 size += "width=";
+			 size += Integer.toString(width);
+			 size += "&height=";
+			 size += Integer.toString(height);
+		}
+		 
+
+		 return size;
+	}*/
+
 
 }


### PR DESCRIPTION
….  Previously, the bounding box would be passed regardless of raster pixel alignment.  This would cause the raster to be transformed to coincide with the bounding box.  Changes made allow for the bounding box to be snapped to the nearest raster pixel edge so that a transformation will not take place.  This was causing a  particular issue with multi-band raster where 0 values in a pixels R,G,B values (i.e. 145,0,79) would be set to the whole pixel to "no-data" in transformation, resulting in pixel holes throughout the image.
